### PR TITLE
feat(queue): Add fairness tests and improve DeleteMessage

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -120,6 +120,12 @@ type ResponseMessage struct {
 	ReceiptHandle          string                    `json:"ReceiptHandle"`
 }
 
+// DeleteMessageRequest defines the parameters for deleting a message.
+type DeleteMessageRequest struct {
+	QueueUrl      string `json:"QueueUrl"`
+	ReceiptHandle string `json:"ReceiptHandle"`
+}
+
 // ErrorResponse defines the standard AWS JSON error response format.
 type ErrorResponse struct {
 	Type    string `json:"__type"`

--- a/store/store.go
+++ b/store/store.go
@@ -14,6 +14,8 @@ var (
 	ErrQueueDoesNotExist = errors.New("queue does not exist")
 	// ErrPurgeQueueInProgress is returned when a purge request is made for a queue that has been purged in the last 60 seconds.
 	ErrPurgeQueueInProgress = errors.New("purge queue in progress")
+	// ErrInvalidReceiptHandle is returned when a receipt handle is malformed or invalid.
+	ErrInvalidReceiptHandle = errors.New("receipt handle is invalid")
 )
 
 // Store is the interface for the underlying storage system.


### PR DESCRIPTION
This commit introduces two main improvements:
1.  Adds fairness tests for FIFO queues to prevent "noisy neighbor" issues.
2.  Implements a more robust `DeleteMessage` API endpoint aligned with the AWS SQS specification.

Fairness Tests:
- `TestFDBStore_FifoQueue_Fairness` in `store/fdb_test.go` and `TestIntegration_FifoFairness` in `main_test.go` were added to confirm that the queue processes messages from different groups fairly.
- The `ReceiveMessage` response was updated to include `MessageGroupId` and `SequenceNumber` in the system attributes to support these tests.

DeleteMessage Implementation:
- The `DeleteMessage` operation in the store and handler now correctly handles non-existent and malformed receipt handles as per SQS docs.
- `DeleteMessage` now returns `nil` (success) for non-existent handles.
- A new `ErrInvalidReceiptHandle` error was added for malformed handles, which results in a `ReceiptHandleIsInvalid` API error.
- Comprehensive unit and integration tests for `DeleteMessage` were added in `fdb_test.go`, `handlers_test.go`, and `main_test.go`.