### PR TITLE
Fix SQS handlers to align with AWS specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ foundationdb-clients_7.3.67-1_amd64.deb
 foundationdb-server_7.3.67-1_amd64.deb
 trace.127.0.0.1.4500.1754841933.ne58Az.0.1.xml*.deb
 *.out
+
+trace.127.0.0.1.4500.1754841933.ne58Az.0.1.xml

--- a/store/fdb_benchmark_test.go
+++ b/store/fdb_benchmark_test.go
@@ -10,8 +10,10 @@ import (
 
 func cleanup(b *testing.B, store *FDBStore, queueName string) {
 	err := store.DeleteQueue(context.Background(), queueName)
-	if err != nil && err != ErrQueueDoesNotExist {
-		b.Logf("Failed to cleanup queue %s: %v", queueName, err)
+	if err != nil {
+		if err.Error() != "queue does not exist" {
+			b.Logf("Failed to cleanup queue %s: %v", queueName, err)
+		}
 	}
 }
 
@@ -36,7 +38,7 @@ func BenchmarkReceiveMessageWithContention(b *testing.B) {
 	defer cleanup(b, store, queueName)
 
 	// Create a standard queue
-	err = store.CreateQueue(context.Background(), queueName, nil, nil)
+	_, err = store.CreateQueue(context.Background(), queueName, nil, nil)
 	if err != nil {
 		b.Fatalf("Failed to create queue: %v", err)
 	}


### PR DESCRIPTION
This commit introduces a number of fixes across several SQS handlers to bring them into closer alignment with the official AWS SQS API specification.

The following handlers were updated:

- CreateQueue: Now correctly handles idempotent requests. If a queue with the same name and attributes exists, it returns a 200 OK. If the attributes differ, it returns a `QueueNameExists` error.
- GetQueueAttributes: The handler now returns a more complete set of default attributes, validates requested attribute names against a comprehensive list, and correctly omits valid but unset attributes from the response.
- SetQueueAttributes: Added validation to prevent the modification of immutable queue attributes.
- ListQueues: Added validation for the `MaxResults` parameter and now correctly omits the `NextToken` from the response if `MaxResults` was not specified by the client.
- SendMessage: Added validation for invalid characters in the message body.
- SendMessageBatch: Added routing for this handler in the main SQS router.
- ChangeMessageVisibilityBatch: Reworked the handler and store logic to correctly handle partial successes and failures. The response now includes separate lists for successful and failed entries.
- DeleteMessageBatch: Added validation for batch entry IDs to ensure they conform to the SQS specification.

To support these changes, the `store.Store` interface was updated, and the `FDBStore` implementation was modified accordingly. Unit, integration, and benchmark tests have been updated to reflect the new, more compliant behavior.